### PR TITLE
TypeScript support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,4 @@
+declare module 'fast-deep-equal' {
+    const equal: (a: any, b: any) => boolean;
+    export = equal;
+}

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     ]
   },
   "files": [
-    "index.js"
+    "index.js",
+    "index.d.ts"
   ],
   "types": "index.d.ts"
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "eslint": "eslint *.js benchmark spec",
     "test-spec": "mocha spec/*.spec.js -R spec",
     "test-cov": "nyc npm run test-spec",
+    "test-ts": "tsc --target ES5 --noImplicitAny index.d.ts",
     "test": "npm run eslint && npm run test-cov"
   },
   "repository": {
@@ -36,6 +37,7 @@
     "nyc": "^11.0.2",
     "pre-commit": "^1.2.2",
     "shallow-equal-fuzzy": "0.0.2",
+    "typescript": "^2.6.1",
     "underscore": "^1.8.3"
   },
   "nyc": {

--- a/package.json
+++ b/package.json
@@ -47,5 +47,6 @@
       "lcov",
       "text-summary"
     ]
-  }
+  },
+  "types": "index.d.ts"
 }


### PR DESCRIPTION
You now can `import` typed `equal` in TypeScript code instead of using untyped `require`

```
import * as equal from 'fast-deep-equal';
```