### PR TITLE
Ignore lock files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,10 @@ typings/
 # Yarn Integrity file
 .yarn-integrity
 
+# Lock files
+package-lock.json
+yarn.lock
+
 # dotenv environment variables file
 .env
 


### PR DESCRIPTION
Just a quick addition to `.gitignore` so that people don't accidentally commit their yarn/npm lock file. (I assumed you didn't want one of those lock files as neither was committed into the repo)