### PR TITLE
Removing object keys double looping

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,12 +40,9 @@ module.exports = function equal(a, b) {
     if (length !== keyList(b).length)
       return false;
 
-    for (i = length; i-- !== 0;)
-      if (!hasProp.call(b, keys[i])) return false;
-
     for (i = length; i-- !== 0;) {
       key = keys[i];
-      if (!equal(a[key], b[key])) return false;
+      if (!hasProp.call(b, key) || !equal(a[key], b[key])) return false;
     }
 
     return true;


### PR DESCRIPTION
While we're at this. I've noticed it's looping through the object keys twice. Merging them into a single loop seem to give it a bit of a speed bump too:
<img width="649" alt="screen shot 2018-04-21 at 8 42 04 am" src="https://user-images.githubusercontent.com/14523/39076778-e17113ac-4540-11e8-880b-601f59f638fe.png">
