### PR TITLE
Dependencies optimisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,7 @@ The fastest is fast-deep-equal
 To run benchmark (requires node.js 6+):
 
 ```bash
-npm install
-npm run build
-node benchmark
+npm run benchmark
 ```
 
 

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -1,0 +1,13 @@
+{
+  "private": true,
+  "devDependencies": {
+    "benchmark": "^2.1.4",
+    "deep-eql": "latest",
+    "deep-equal": "latest",
+    "lodash": "latest",
+    "nano-equal": "latest",
+    "ramda": "latest",
+    "shallow-equal-fuzzy": "latest",
+    "underscore": "latest"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "eslint": "eslint *.js benchmark spec",
     "build": "node build",
+    "benchmark": "npm i && npm run build && cd ./benchmark && npm i && node ./",
     "test-spec": "mocha spec/*.spec.js -R spec",
     "test-cov": "nyc npm run test-spec",
     "test-ts": "tsc --target ES5 --noImplicitAny index.d.ts",
@@ -28,21 +29,13 @@
   },
   "homepage": "https://github.com/epoberezkin/fast-deep-equal#readme",
   "devDependencies": {
-    "benchmark": "^2.1.4",
     "coveralls": "^2.13.1",
-    "deep-eql": "latest",
-    "deep-equal": "latest",
     "dot": "^1.1.2",
     "eslint": "^4.0.0",
-    "lodash": "latest",
     "mocha": "^3.4.2",
-    "nano-equal": "latest",
     "nyc": "^11.0.2",
     "pre-commit": "^1.2.2",
-    "ramda": "latest",
-    "shallow-equal-fuzzy": "latest",
-    "typescript": "^2.6.1",
-    "underscore": "latest"
+    "typescript": "^2.6.1"
   },
   "nyc": {
     "exclude": [


### PR DESCRIPTION
- Separated benchmarks-related dependencies to different `package.json`.  
There is no need to install these dependencies for those who not planning to run benches;
- Added npm script to run benchmarks `npm run benchmark`;