### PR TITLE
Code optimisations

### DIFF
--- a/src/index.jst
+++ b/src/index.jst
@@ -12,7 +12,7 @@ module.exports = function equal(a, b) {
   if (a && b && typeof a ==='object' && typeof b ==='object') {
     if (a.constructor !== b.constructor) return false;
 
-    var length, i, key;
+    var length, i, keys;
     if (Array.isArray(a)) {
       length = a.length;
       if (length !== b.length) return false;
@@ -22,25 +22,22 @@ module.exports = function equal(a, b) {
     }
 
 {{? it.es6 }}
-    var keys;
     if (a instanceof Map) {
       if (a.size !== b.size) return false;
-      // should be named `iterator` for the sake of variables efficiency
-      keys = a.entries();
-      while ((i = keys.next()) && !i.done) {
-        if (!b.has(i.value[0])) return false;
-        if (!equal(i.value[1], b.get(i.value[0]))) return false;
-      }
+      for(i of a.entries())
+        if (!b.has(i[0])) return false;
+
+      for(i of a.entries())
+        if (!equal(i[1], b.get(i[0]))) return false;
 
       return true;
     }
 
     if (a instanceof Set) {
       if (a.size !== b.size) return false;
-      // should be named `iterator` for the sake of variables efficiency
-      keys = a.entries();
-      while ((i = keys.next()) && !i.done)
-        if (!b.has(i.value[0])) return false;
+      for(i of a.entries())
+        if (!b.has(i[0])) return false;
+
       return true;
     }
 
@@ -68,16 +65,20 @@ module.exports = function equal(a, b) {
     if (a.valueOf !== Object.prototype.valueOf) return a.valueOf() === b.valueOf();
     if (a.toString !== Object.prototype.toString) return a.toString() === b.toString();
 
-    if (Object.keys(a).length !== Object.keys(b).length) return false;
+    keys = Object.keys(a);
+    length = keys.length;
 
-    for(key in a){
-      if (Object.prototype.hasOwnProperty.call(a, key) !== Object.prototype.hasOwnProperty.call(b, key)) return false;
-      if (!equal(a[key], b[key])) return false;
-    }
+    if (length !== Object.keys(b).length) return false;
+
+    for (i = length; i-- !== 0;)
+      if (!Object.prototype.hasOwnProperty.call(b, keys[i])) return false;
+
+    for (i = length; i-- !== 0;)
+      if (!equal(a[keys[i]], b[keys[i]])) return false;
 
     return true;
   }
 
   // true if both NaN, false otherwise
-  return a !== a && b !== b;
+  return a!==a && b!==b;
 };

--- a/src/index.jst
+++ b/src/index.jst
@@ -2,32 +2,34 @@
 
 // do not edit .js files directly - edit src/index.jst
 
+{{? it.es6 }}
+var envHasBigInt64Array = typeof BigInt64Array !== 'undefined';
+{{?}}
+
 module.exports = function equal(a, b) {
   if (a === b) return true;
 
-  if (a && b && typeof a == 'object' && typeof b == 'object') {
+  if (a && b && typeof a ==='object' && typeof b ==='object') {
     if (a.constructor !== b.constructor) return false;
 
-    var length, i, key, keys;
+    var length, i, key;
     if (Array.isArray(a)) {
       length = a.length;
-      if (length != b.length) return false;
+      if (length !== b.length) return false;
       for (i = length; i-- !== 0;)
         if (!equal(a[i], b[i])) return false;
       return true;
     }
 
 {{? it.es6 }}
+    var keys;
     if (a instanceof Map) {
       if (a.size !== b.size) return false;
-
-      keys = getKeys(a);
-      for (i = a.size; i-- !== 0;)
-        if (!b.has(keys[i])) return false;
-
-      for (i = a.size; i-- !== 0;) {
-        key = keys[i];
-        if (!equal(a.get(key), b.get(key))) return false;
+      // should be named `iterator` for the sake of variables efficiency
+      keys = a.entries();
+      while ((i = keys.next()) && !i.done) {
+        if (!b.has(i.value[0])) return false;
+        if (!equal(i.value[1], b.get(i.value[0]))) return false;
       }
 
       return true;
@@ -35,11 +37,10 @@ module.exports = function equal(a, b) {
 
     if (a instanceof Set) {
       if (a.size !== b.size) return false;
-
-      keys = getKeys(a);
-      for (i = a.size; i-- !== 0;)
-        if (!b.has(keys[i])) return false;
-
+      // should be named `iterator` for the sake of variables efficiency
+      keys = a.entries();
+      while ((i = keys.next()) && !i.done)
+        if (!b.has(i.value[0])) return false;
       return true;
     }
 
@@ -53,11 +54,10 @@ module.exports = function equal(a, b) {
       a instanceof Uint32Array ||
       a instanceof Float32Array ||
       a instanceof Float64Array ||
-      a instanceof BigInt64Array ||
-      a instanceof BigUint64Array
+      (envHasBigInt64Array && (a instanceof BigInt64Array || a instanceof BigUint64Array))
     )) {
       length = a.length;
-      if (length != b.length) return false;
+      if (length !== b.length) return false;
       for (i = length; i-- !== 0;)
         if (a[i] !== b[i]) return false;
       return true;
@@ -68,15 +68,10 @@ module.exports = function equal(a, b) {
     if (a.valueOf !== Object.prototype.valueOf) return a.valueOf() === b.valueOf();
     if (a.toString !== Object.prototype.toString) return a.toString() === b.toString();
 
-    keys = Object.keys(a);
-    length = keys.length;
-    if (length !== Object.keys(b).length) return false;
+    if (Object.keys(a).length !== Object.keys(b).length) return false;
 
-    for (i = length; i-- !== 0;)
-      if (!Object.prototype.hasOwnProperty.call(b, keys[i])) return false;
-
-    for (i = length; i-- !== 0;) {
-      key = keys[i];
+    for(key in a){
+      if (Object.prototype.hasOwnProperty.call(a, key) !== Object.prototype.hasOwnProperty.call(b, key)) return false;
       if (!equal(a[key], b[key])) return false;
     }
 
@@ -84,13 +79,5 @@ module.exports = function equal(a, b) {
   }
 
   // true if both NaN, false otherwise
-  return a!==a && b!==b;
+  return a !== a && b !== b;
 };
-
-{{? it.es6 }}
-function getKeys(a) {
-  var keys = [];
-  for (var [key] of a.entries()) keys.push(key);
-  return keys;
-}
-{{?}}


### PR DESCRIPTION
- Improved performance of Map and Set;
- Fix: #35;

Benchmarks (not default):
```bash
* local/es6           # Map (equal) x 5,164,902 ops/sec ±0.46% (92 runs sampled)
* fast-deep-equal/es6 # Map (equal) x 3,509,397 ops/sec ±0.22% (94 runs sampled)

> Fastest is local/es6 # Map (equal)

* local/es6           # Map (unequal) x 5,920,068 ops/sec ±0.75% (91 runs sampled)
* fast-deep-equal/es6 # Map (unequal) x 4,076,101 ops/sec ±1.62% (92 runs sampled)

> Fastest is local/es6 # Map (unequal)

* local/es6           # Set (equal) x 2,844,644 ops/sec ±0.52% (94 runs sampled)
* fast-deep-equal/es6 # Set (equal) x 1,424,040 ops/sec ±0.25% (94 runs sampled)

> Fastest is local/es6 # Set (equal)

* local/es6           # Set (unequal) x 3,349,728 ops/sec ±0.43% (93 runs sampled)
* fast-deep-equal/es6 # Set (unequal) x 2,319,039 ops/sec ±0.37% (93 runs sampled)

> Fastest is local/es6 # Set (unequal)
```

Benchmarks (default one):
```bash
fast-deep-equal x 212,783 ops/sec ±0.35% (83 runs sampled)
fast-deep-equal/es6 x 172,554 ops/sec ±0.23% (96 runs sampled)
nano-equal x 157,959 ops/sec ±0.44% (89 runs sampled)
shallow-equal-fuzzy x 129,607 ops/sec ±0.28% (93 runs sampled)
underscore.isEqual x 86,097 ops/sec ±0.63% (90 runs sampled)
lodash.isEqual x 30,583 ops/sec ±0.92% (93 runs sampled)
deep-equal x 43,955 ops/sec ±1.21% (95 runs sampled)
deep-eql x 29,686 ops/sec ±1.11% (94 runs sampled)
ramda.equals x 9,582 ops/sec ±0.77% (94 runs sampled)
util.isDeepStrictEqual x 40,327 ops/sec ±0.44% (91 runs sampled)
assert.deepStrictEqual x 557 ops/sec ±0.87% (80 runs sampled)
```