### PR TITLE
Fixes

### DIFF
--- a/spec/es6tests.js
+++ b/spec/es6tests.js
@@ -138,7 +138,18 @@ module.exports = [
         value1: undefined,
         value2: new Map,
         equal: false
-      }
+      },
+      {
+        description: 'map and a pseudo map are not equal',
+        value1: map({}),
+        value2: {
+          constructor: Map,
+          size: 0,
+          has: () => true,
+          get: () => 1,
+        },
+        equal: false
+      },
     ]
   },
 
@@ -228,7 +239,17 @@ module.exports = [
         value1: set([undefined]),
         value2: set([]),
         equal: false
-      }
+      },
+      {
+        description: 'set and pseudo set are not equal',
+        value1: new Set,
+        value2: {
+          constructor: Set,
+          size: 0,
+          has: () => true,
+        },
+        equal: false
+      },
     ]
   },
 

--- a/spec/es6tests.js
+++ b/spec/es6tests.js
@@ -287,7 +287,7 @@ module.exports = [
       },
       {
         description: 'pseudo array and equivalent typed array are not equal',
-        value1: {'0': 1, '1': 2, length: 2},
+        value1: {'0': 1, '1': 2, length: 2, constructor: Int32Array},
         value2: new Int32Array([1, 2]),
         equal: false
       }

--- a/spec/index.spec.js
+++ b/spec/index.spec.js
@@ -16,6 +16,9 @@ function testCases(equalFunc, suiteName, suiteTests) {
           (test.skip ? it.skip : it)(test.description, function() {
             assert.strictEqual(equalFunc(test.value1, test.value2), test.equal);
           });
+          (test.skip ? it.skip : it)(test.description + ' (reverse arguments)', function() {
+            assert.strictEqual(equalFunc(test.value2, test.value1), test.equal);
+          });
         });
       });
     });

--- a/src/index.jst
+++ b/src/index.jst
@@ -22,22 +22,19 @@ module.exports = function equal(a, b) {
     }
 
 {{? it.es6 }}
-    if (a instanceof Map) {
+    if ((a instanceof Map) && (b instanceof Map)) {
       if (a.size !== b.size) return false;
-      for(i of a.entries())
+      for (i of a.entries())
         if (!b.has(i[0])) return false;
-
-      for(i of a.entries())
+      for (i of a.entries())
         if (!equal(i[1], b.get(i[0]))) return false;
-
       return true;
     }
 
-    if (a instanceof Set) {
+    if ((a instanceof Set) && (b instanceof Set)) {
       if (a.size !== b.size) return false;
-      for(i of a.entries())
+      for (i of a.entries())
         if (!b.has(i[0])) return false;
-
       return true;
     }
 

--- a/src/index.jst
+++ b/src/index.jst
@@ -41,18 +41,7 @@ module.exports = function equal(a, b) {
       return true;
     }
 
-    if (a.constructor.BYTES_PER_ELEMENT && (
-      a instanceof Int8Array ||
-      a instanceof Uint8Array ||
-      a instanceof Uint8ClampedArray ||
-      a instanceof Int16Array ||
-      a instanceof Uint16Array ||
-      a instanceof Int32Array ||
-      a instanceof Uint32Array ||
-      a instanceof Float32Array ||
-      a instanceof Float64Array ||
-      (envHasBigInt64Array && (a instanceof BigInt64Array || a instanceof BigUint64Array))
-    )) {
+    if (ArrayBuffer.isView(a) && ArrayBuffer.isView(b)) {
       length = a.length;
       if (length != b.length) return false;
       for (i = length; i-- !== 0;)


### PR DESCRIPTION
- Return consistent results `equal(x, y) == equal(y, x)`.
- Return `false` for pseudo `Map`, `Set` and `TypedArray` objects.