### PR TITLE
fixes typings (possibly closes #9 and closes #40)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,5 @@ yarn.lock
 # generated files
 index.js
 react.js
+
+.idea

--- a/es6/index.d.ts
+++ b/es6/index.d.ts
@@ -1,2 +1,2 @@
-const equal: (a: any, b: any) => boolean;
+declare const equal: (a: any, b: any) => boolean;
 export = equal;

--- a/es6/react.d.ts
+++ b/es6/react.d.ts
@@ -1,2 +1,2 @@
-const equal: (a: any, b: any) => boolean;
+declare const equal: (a: any, b: any) => boolean;
 export = equal;

--- a/react.d.ts
+++ b/react.d.ts
@@ -1,2 +1,2 @@
-const equal: (a: any, b: any) => boolean;
+declare const equal: (a: any, b: any) => boolean;
 export = equal;


### PR DESCRIPTION
Closes #9  and Closes #40 

This should fix a problem with `Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier.`