### PR TITLE
fix: Fix ES6 TypeScript definition files

### DIFF
--- a/es6/index.d.ts
+++ b/es6/index.d.ts
@@ -1,2 +1,4 @@
-const equal: (a: any, b: any) => boolean;
-export = equal;
+declare module 'fast-deep-equal/es6' {
+    const equal: (a: any, b: any) => boolean;
+    export = equal;
+}

--- a/es6/react.d.ts
+++ b/es6/react.d.ts
@@ -1,2 +1,4 @@
-const equal: (a: any, b: any) => boolean;
-export = equal;
+declare module 'fast-deep-equal/es6/react' {
+    const equal: (a: any, b: any) => boolean;
+    export = equal;
+}


### PR DESCRIPTION
Following the type definitions on `./index.d.ts` and `./react.d.ts`, we need to use `declare module` on TypeScript definition files.

I've published a proof-of-concept on npm (also because I needed it now) as [fast-deep-equal-ts](https://www.npmjs.com/package/fast-deep-equal-ts). It will be deprecated once this is released.

Closes #9 
Closes #40 
Closes #48 