### PR TITLE
Update TypeScript typings

### DIFF
--- a/es6/index.d.ts
+++ b/es6/index.d.ts
@@ -1,2 +1,2 @@
-declare const equal: (a: any, b: any) => boolean;
-export = equal;
+declare function equal<T>(actual: any, expected: T): actual is T
+export = equal

--- a/es6/react.d.ts
+++ b/es6/react.d.ts
@@ -1,2 +1,2 @@
-declare const equal: (a: any, b: any) => boolean;
-export = equal;
+declare function equal<T>(actual: any, expected: T): actual is T
+export = equal

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,2 @@
-declare module 'fast-deep-equal' {
-    const equal: (a: any, b: any) => boolean;
-    export = equal;
-}
+declare function equal<T>(actual: any, expected: T): actual is T
+export = equal

--- a/react.d.ts
+++ b/react.d.ts
@@ -1,2 +1,2 @@
-declare const equal: (a: any, b: any) => boolean;
-export = equal;
+declare function equal<T>(actual: any, expected: T): actual is T
+export = equal


### PR DESCRIPTION
- Fix `ts1046` error (Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier)
- Types the return value as `is actual` so that TypeScript can know how to infer types (similar to this in `assert` https://github.com/DefinitelyTyped/DefinitelyTyped/pull/41616)

Fixes #9 
Fixes #40 
Closes #48 
Closes #51 