### PR TITLE
Adds check for valueOf/stringOf existence

### DIFF
--- a/src/index.jst
+++ b/src/index.jst
@@ -48,8 +48,8 @@ module.exports = function equal(a, b) {
 {{?}}
 
     if (a.constructor === RegExp) return a.source === b.source && a.flags === b.flags;
-    if (a.valueOf && a.valueOf !== Object.prototype.valueOf) return a.valueOf() === b.valueOf();
-    if (a.toString && a.toString !== Object.prototype.toString) return a.toString() === b.toString();
+    if (a.valueOf !== Object.prototype.valueOf && a.valueOf) return a.valueOf() === b.valueOf();
+    if (a.toString !== Object.prototype.toString && a.toString) return a.toString() === b.toString();
 
     keys = Object.keys(a);
     length = keys.length;

--- a/src/index.jst
+++ b/src/index.jst
@@ -48,8 +48,8 @@ module.exports = function equal(a, b) {
 {{?}}
 
     if (a.constructor === RegExp) return a.source === b.source && a.flags === b.flags;
-    if (a.valueOf !== Object.prototype.valueOf) return a.valueOf() === b.valueOf();
-    if (a.toString !== Object.prototype.toString) return a.toString() === b.toString();
+    if (a.valueOf && a.valueOf !== Object.prototype.valueOf) return a.valueOf() === b.valueOf();
+    if (a.toString && a.toString !== Object.prototype.toString) return a.toString() === b.toString();
 
     keys = Object.keys(a);
     length = keys.length;


### PR DESCRIPTION
When utilising this in a React context I was getting exceptions where `a.valueOf` / `a.toString` did not exist. The current logic didn't take this into account, leading to an exception when it tried to execute said functions.

I patched my local copy of your package with this fix and it worked great thereafter.

Here are the benchmark results post this patch:

```
fast-deep-equal x 280,216 ops/sec ±0.56% (90 runs sampled)
fast-deep-equal/es6 x 237,314 ops/sec ±0.55% (85 runs sampled)
fast-equals x 258,718 ops/sec ±0.58% (89 runs sampled)
nano-equal x 201,614 ops/sec ±0.54% (89 runs sampled)
shallow-equal-fuzzy x 154,959 ops/sec ±0.77% (90 runs sampled)
underscore.isEqual x 97,879 ops/sec ±0.53% (91 runs sampled)
lodash.isEqual x 40,880 ops/sec ±0.60% (89 runs sampled)
deep-equal x 196 ops/sec ±1.42% (58 runs sampled)
deep-eql x 44,681 ops/sec ±0.63% (90 runs sampled)
ramda.equals x 13,237 ops/sec ±0.83% (89 runs sampled)
util.isDeepStrictEqual x 59,043 ops/sec ±0.55% (89 runs sampled)
assert.deepStrictEqual x 503 ops/sec ±0.56% (87 runs sampled)
The fastest is fast-deep-equal
```