### PR TITLE
changing "flags" to single properties

### DIFF
--- a/src/index.jst
+++ b/src/index.jst
@@ -47,7 +47,17 @@ module.exports = function equal(a, b) {
     }
 {{?}}
 
-    if (a.constructor === RegExp) return a.source === b.source && a.flags === b.flags;
+    if (a.constructor === RegExp) {
+      return a.source === b.source
+        && a.global === b.global
+        && a.ignoreCase === b.ignoreCase
+        && a.multiline === b.multiline
+        && a.unicode === b.unicode
+        && a.lastIndex === b.lastIndex
+        && a.sticky === b.sticky
+      ;
+    }
+
     if (a.valueOf !== Object.prototype.valueOf) return a.valueOf() === b.valueOf();
     if (a.toString !== Object.prototype.toString) return a.toString() === b.toString();
 


### PR DESCRIPTION
According to MDN (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/flags), the RegExp.prototype.flags property is not supported by IE. This will result in an error in this test > "description: 'not equal RegExp objects (different flags)',"