### PR TITLE
Add support for ESM modules

### DIFF
--- a/build.js
+++ b/build.js
@@ -10,3 +10,6 @@ fs.writeFileSync('./react.js', jst({es6: false, react: true}));
 try { fs.mkdirSync('./es6'); }  catch(e) {}
 fs.writeFileSync('./es6/index.js', jst({es6: true}));
 fs.writeFileSync('./es6/react.js', jst({es6: true, react: true}));
+try { fs.mkdirSync('./esm'); }  catch(e) {}
+fs.writeFileSync('./esm/index.js', jst({es6: true, esm: true}));
+fs.writeFileSync('./esm/react.js', jst({es6: true, esm: true, react: true}));

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.1.3",
   "description": "Fast deep equal",
   "main": "index.js",
+  "module": "esm/index.js",
   "scripts": {
     "eslint": "eslint *.js benchmark/*.js spec/*.js",
     "build": "node build",
@@ -55,7 +56,8 @@
     "index.d.ts",
     "react.js",
     "react.d.ts",
-    "es6/"
+    "es6/",
+    "esm/"
   ],
   "types": "index.d.ts"
 }

--- a/src/index.jst
+++ b/src/index.jst
@@ -6,7 +6,12 @@
   var envHasBigInt64Array = typeof BigInt64Array !== 'undefined';
 {{?}}
 
+{{? it.esm }}
+export default function equal(a, b) {
+{{?}}
+{{? !it.esm }}
 module.exports = function equal(a, b) {
+{{?}}
   if (a === b) return true;
 
   if (a && b && typeof a == 'object' && typeof b == 'object') {


### PR DESCRIPTION
Hey! Storybook uses this package as a dependency, and I noticed that it doesn't expose ESM modules - but it's quite easy to add support for. What do you think about this PR?

This generates ESM module syntax ("export default")
in a separate esm/ directory.

For simplicity, it assumes that if you want to use
ESM modules, you also have ES6 features in your
environment, so the build script turns that on as well.

The esm index.js is exposed through the "module" field
in package.json.