### PR TITLE
Consider combining loops that iterate `Map` (ie revert back to breadth first search)

### DIFF
--- a/src/index.jst
+++ b/src/index.jst
@@ -24,10 +24,10 @@ module.exports = function equal(a, b) {
 {{? it.es6 }}
     if ((a instanceof Map) && (b instanceof Map)) {
       if (a.size !== b.size) return false;
-      for (i of a.entries())
+      for (i of a.entries()) {
         if (!b.has(i[0])) return false;
-      for (i of a.entries())
         if (!equal(i[1], b.get(i[0]))) return false;
+      }
       return true;
     }
 


### PR DESCRIPTION
This change uses the same  `entries()` iterator to iterate over testing key/value pairs.

See https://github.com/epoberezkin/fast-deep-equal/commit/3e8c0565f19a20d4ecf8941ee6b8d0b8c3a88e88#diff-443d5464f90756fa4d7b70e3b5232f7b86ddeeca5d98581a0450a6ce08033e0dL30-R31

In 3e8c0565f19 it was helpful to use `entries()` rather than `keys()`. But 3e8c0565f19 also changed a breadth first search to a depth first search.  This depth first search requires an extra `entries()` iterator.  Is there value doing a depth first search? (ie testing all keys first then proceeding to values)

While this change does reduce code, the performance benefit really depends on the data...  When I use the existing benchmarks, I am seeing slightly better performance with this change (which is a breadth first search) of the `Map`.  But I can also envision different data that performs better with a depth first search...  

I am curious to whether people think a Depth First or Breadth First search of a Map is better for their data.

@xobotyi is there a reason you chose to change it from breadth first to depth first?