### PR TITLE
Only iterate over `Map`s once

### DIFF
--- a/src/index.jst
+++ b/src/index.jst
@@ -24,10 +24,10 @@ module.exports = function equal(a, b) {
 {{? it.es6 }}
     if ((a instanceof Map) && (b instanceof Map)) {
       if (a.size !== b.size) return false;
-      for (i of a.entries())
+      for (i of a.entries()) {
         if (!b.has(i[0])) return false;
-      for (i of a.entries())
         if (!equal(i[1], b.get(i[0]))) return false;
+      }
       return true;
     }
 


### PR DESCRIPTION
Before this commit, the logic was (roughly):

1. For each key of `a`, make sure the key is present in `b`.
2. For each key of `a`, make sure the corresponding value in `b` is equal.

Now, there's only one loop. The logic is now:

1. For each key of `a`...
   1. Make sure the key is present in `b`.
   2. Make sure the corresponding value in `b` is equal.