### PR TITLE
Prefer `Set.prototype.values()` over `.entries()`

### DIFF
--- a/src/index.jst
+++ b/src/index.jst
@@ -33,8 +33,8 @@ module.exports = function equal(a, b) {
 
     if ((a instanceof Set) && (b instanceof Set)) {
       if (a.size !== b.size) return false;
-      for (i of a.entries())
-        if (!b.has(i[0])) return false;
+      for (i of a.values())
+        if (!b.has(i)) return false;
       return true;
     }
 


### PR DESCRIPTION
Each iteration value in [`Set.prototype.entries()`][0] is an array of two identical values:

    const mySet = new Set(['a' , 'b', 'c']);
    console.log([...mySet.entries()]);
    // => [ [ 'a', 'a' ], [ 'b', 'b' ], [ 'c', 'c' ] ]

That's unnecessary for this library, which can just use [`Set.prototype.values()`][1].

    const mySet = new Set(['a' , 'b', 'c']);
    console.log([...mySet.values()]);
    // => [ 'a', 'b', 'c' ]

This simplifies the code a bit and should result in a small speed improvement.

[0]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/entries
[1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/values