### PR TITLE
bugfix: objects without valueOf  and toString  function do not throw error

### DIFF
--- a/spec/tests.js
+++ b/spec/tests.js
@@ -120,50 +120,50 @@ module.exports = [
       },
       {
         description: 'equal objects (same properties "order")',
-        value1: { a: 1, b: '2' },
-        value2: { a: 1, b: '2' },
+        value1: {a: 1, b: '2'},
+        value2: {a: 1, b: '2'},
         equal: true
       },
       {
         description: 'equal objects (different properties "order")',
-        value1: { a: 1, b: '2' },
-        value2: { b: '2', a: 1 },
+        value1: {a: 1, b: '2'},
+        value2: {b: '2', a: 1},
         equal: true
       },
       {
         description: 'not equal objects (extra property)',
-        value1: { a: 1, b: '2' },
-        value2: { a: 1, b: '2', c: [] },
+        value1: {a: 1, b: '2'},
+        value2: {a: 1, b: '2', c: []},
         equal: false
       },
       {
         description: 'not equal objects (different property values)',
-        value1: { a: 1, b: '2', c: 3 },
-        value2: { a: 1, b: '2', c: 4 },
+        value1: {a: 1, b: '2', c: 3},
+        value2: {a: 1, b: '2', c: 4},
         equal: false
       },
       {
         description: 'not equal objects (different properties)',
-        value1: { a: 1, b: '2', c: 3 },
-        value2: { a: 1, b: '2', d: 3 },
+        value1: {a: 1, b: '2', c: 3},
+        value2: {a: 1, b: '2', d: 3},
         equal: false
       },
       {
         description: 'equal objects (same sub-properties)',
-        value1: { a: [{ b: 'c' }] },
-        value2: { a: [{ b: 'c' }] },
+        value1: { a: [ { b: 'c' } ] },
+        value2: { a: [ { b: 'c' } ] },
         equal: true
       },
       {
         description: 'not equal objects (different sub-property value)',
-        value1: { a: [{ b: 'c' }] },
-        value2: { a: [{ b: 'd' }] },
+        value1: { a: [ { b: 'c' } ] },
+        value2: { a: [ { b: 'd' } ] },
         equal: false
       },
       {
         description: 'not equal objects (different sub-property)',
-        value1: { a: [{ b: 'c' }] },
-        value2: { a: [{ c: 'c' }] },
+        value1: { a: [ { b: 'c' } ] },
+        value2: { a: [ { c: 'c' } ] },
         equal: false
       },
       {
@@ -175,19 +175,19 @@ module.exports = [
       {
         description: 'object with extra undefined properties are not equal #1',
         value1: {},
-        value2: { foo: undefined },
+        value2: {foo: undefined},
         equal: false
       },
       {
         description: 'object with extra undefined properties are not equal #2',
-        value1: { foo: undefined },
+        value1: {foo: undefined},
         value2: {},
         equal: false
       },
       {
         description: 'object with extra undefined properties are not equal #3',
-        value1: { foo: undefined },
-        value2: { bar: undefined },
+        value1: {foo: undefined},
+        value2: {bar: undefined},
         equal: false
       },
       {
@@ -216,14 +216,14 @@ module.exports = [
       },
       {
         description: 'objects with different `toString` functions returning same values are equal',
-        value1: { toString: () => 'Hello world!' },
-        value2: { toString: () => 'Hello world!' },
+        value1: {toString: ()=>'Hello world!'},
+        value2: {toString: ()=>'Hello world!'},
         equal: true
       },
       {
         description: 'objects with `toString` functions returning different values are not equal',
-        value1: { toString: () => 'Hello world!' },
-        value2: { toString: () => 'Hi!' },
+        value1: {toString: ()=>'Hello world!'},
+        value2: {toString: ()=>'Hi!'},
         equal: false
       },
       {
@@ -264,19 +264,19 @@ module.exports = [
       },
       {
         description: 'equal arrays of objects',
-        value1: [{ a: 'a' }, { b: 'b' }],
-        value2: [{ a: 'a' }, { b: 'b' }],
+        value1: [{a: 'a'}, {b: 'b'}],
+        value2: [{a: 'a'}, {b: 'b'}],
         equal: true
       },
       {
         description: 'not equal arrays of objects',
-        value1: [{ a: 'a' }, { b: 'b' }],
-        value2: [{ a: 'a' }, { b: 'c' }],
+        value1: [{a: 'a'}, {b: 'b'}],
+        value2: [{a: 'a'}, {b: 'c'}],
         equal: false
       },
       {
         description: 'pseudo array and equivalent array are not equal',
-        value1: { '0': 0, '1': 1, length: 2 },
+        value1: {'0': 0, '1': 1, length: 2},
         value2: [0, 1],
         equal: false
       }
@@ -376,7 +376,7 @@ module.exports = [
             subProp1: 'sub value1',
             subProp2: {
               subSubProp1: 'sub sub value1',
-              subSubProp2: [1, 2, { prop2: 1, prop: 2 }, 4, 5]
+              subSubProp2: [1, 2, {prop2: 1, prop: 2}, 4, 5]
             }
           },
           prop5: 1000,
@@ -391,7 +391,7 @@ module.exports = [
           prop4: {
             subProp2: {
               subSubProp1: 'sub sub value1',
-              subSubProp2: [1, 2, { prop2: 1, prop: 2 }, 4, 5]
+              subSubProp2: [1, 2, {prop2: 1, prop: 2}, 4, 5]
             },
             subProp1: 'sub value1'
           }
@@ -402,5 +402,5 @@ module.exports = [
   }
 ];
 
-function func1() { }
-function func2() { }
+function func1() {}
+function func2() {}

--- a/spec/tests.js
+++ b/spec/tests.js
@@ -120,50 +120,50 @@ module.exports = [
       },
       {
         description: 'equal objects (same properties "order")',
-        value1: {a: 1, b: '2'},
-        value2: {a: 1, b: '2'},
+        value1: { a: 1, b: '2' },
+        value2: { a: 1, b: '2' },
         equal: true
       },
       {
         description: 'equal objects (different properties "order")',
-        value1: {a: 1, b: '2'},
-        value2: {b: '2', a: 1},
+        value1: { a: 1, b: '2' },
+        value2: { b: '2', a: 1 },
         equal: true
       },
       {
         description: 'not equal objects (extra property)',
-        value1: {a: 1, b: '2'},
-        value2: {a: 1, b: '2', c: []},
+        value1: { a: 1, b: '2' },
+        value2: { a: 1, b: '2', c: [] },
         equal: false
       },
       {
         description: 'not equal objects (different property values)',
-        value1: {a: 1, b: '2', c: 3},
-        value2: {a: 1, b: '2', c: 4},
+        value1: { a: 1, b: '2', c: 3 },
+        value2: { a: 1, b: '2', c: 4 },
         equal: false
       },
       {
         description: 'not equal objects (different properties)',
-        value1: {a: 1, b: '2', c: 3},
-        value2: {a: 1, b: '2', d: 3},
+        value1: { a: 1, b: '2', c: 3 },
+        value2: { a: 1, b: '2', d: 3 },
         equal: false
       },
       {
         description: 'equal objects (same sub-properties)',
-        value1: { a: [ { b: 'c' } ] },
-        value2: { a: [ { b: 'c' } ] },
+        value1: { a: [{ b: 'c' }] },
+        value2: { a: [{ b: 'c' }] },
         equal: true
       },
       {
         description: 'not equal objects (different sub-property value)',
-        value1: { a: [ { b: 'c' } ] },
-        value2: { a: [ { b: 'd' } ] },
+        value1: { a: [{ b: 'c' }] },
+        value2: { a: [{ b: 'd' }] },
         equal: false
       },
       {
         description: 'not equal objects (different sub-property)',
-        value1: { a: [ { b: 'c' } ] },
-        value2: { a: [ { c: 'c' } ] },
+        value1: { a: [{ b: 'c' }] },
+        value2: { a: [{ c: 'c' }] },
         equal: false
       },
       {
@@ -175,19 +175,19 @@ module.exports = [
       {
         description: 'object with extra undefined properties are not equal #1',
         value1: {},
-        value2: {foo: undefined},
+        value2: { foo: undefined },
         equal: false
       },
       {
         description: 'object with extra undefined properties are not equal #2',
-        value1: {foo: undefined},
+        value1: { foo: undefined },
         value2: {},
         equal: false
       },
       {
         description: 'object with extra undefined properties are not equal #3',
-        value1: {foo: undefined},
-        value2: {bar: undefined},
+        value1: { foo: undefined },
+        value2: { bar: undefined },
         equal: false
       },
       {
@@ -216,15 +216,21 @@ module.exports = [
       },
       {
         description: 'objects with different `toString` functions returning same values are equal',
-        value1: {toString: ()=>'Hello world!'},
-        value2: {toString: ()=>'Hello world!'},
+        value1: { toString: () => 'Hello world!' },
+        value2: { toString: () => 'Hello world!' },
         equal: true
       },
       {
         description: 'objects with `toString` functions returning different values are not equal',
-        value1: {toString: ()=>'Hello world!'},
-        value2: {toString: ()=>'Hi!'},
+        value1: { toString: () => 'Hello world!' },
+        value2: { toString: () => 'Hi!' },
         equal: false
+      },
+      {
+        description: 'objects without `valueOf` and `toString` function do not throw error',
+        value1: Object.assign(Object.create(null), { a: 1 }),
+        value2: Object.assign(Object.create(null), { a: 1 }),
+        equal: true
       }
     ]
   },
@@ -258,19 +264,19 @@ module.exports = [
       },
       {
         description: 'equal arrays of objects',
-        value1: [{a: 'a'}, {b: 'b'}],
-        value2: [{a: 'a'}, {b: 'b'}],
+        value1: [{ a: 'a' }, { b: 'b' }],
+        value2: [{ a: 'a' }, { b: 'b' }],
         equal: true
       },
       {
         description: 'not equal arrays of objects',
-        value1: [{a: 'a'}, {b: 'b'}],
-        value2: [{a: 'a'}, {b: 'c'}],
+        value1: [{ a: 'a' }, { b: 'b' }],
+        value2: [{ a: 'a' }, { b: 'c' }],
         equal: false
       },
       {
         description: 'pseudo array and equivalent array are not equal',
-        value1: {'0': 0, '1': 1, length: 2},
+        value1: { '0': 0, '1': 1, length: 2 },
         value2: [0, 1],
         equal: false
       }
@@ -370,7 +376,7 @@ module.exports = [
             subProp1: 'sub value1',
             subProp2: {
               subSubProp1: 'sub sub value1',
-              subSubProp2: [1, 2, {prop2: 1, prop: 2}, 4, 5]
+              subSubProp2: [1, 2, { prop2: 1, prop: 2 }, 4, 5]
             }
           },
           prop5: 1000,
@@ -385,7 +391,7 @@ module.exports = [
           prop4: {
             subProp2: {
               subSubProp1: 'sub sub value1',
-              subSubProp2: [1, 2, {prop2: 1, prop: 2}, 4, 5]
+              subSubProp2: [1, 2, { prop2: 1, prop: 2 }, 4, 5]
             },
             subProp1: 'sub value1'
           }
@@ -396,5 +402,5 @@ module.exports = [
   }
 ];
 
-function func1() {}
-function func2() {}
+function func1() { }
+function func2() { }

--- a/src/index.jst
+++ b/src/index.jst
@@ -48,8 +48,8 @@ module.exports = function equal(a, b) {
 {{?}}
 
     if (a.constructor === RegExp) return a.source === b.source && a.flags === b.flags;
-    if (a.valueOf !== Object.prototype.valueOf) return a.valueOf() === b.valueOf();
-    if (a.toString !== Object.prototype.toString) return a.toString() === b.toString();
+    if (a.valueOf !== Object.prototype.valueOf && typeof a.valueOf === 'function' && typeof b.valueOf === 'function') return a.valueOf() === b.valueOf();
+    if (a.toString !== Object.prototype.toString && typeof a.toString === 'function' && typeof b.toString === 'function') return a.toString() === b.toString();
 
     keys = Object.keys(a);
     length = keys.length;


### PR DESCRIPTION
Fix #111.

As mentioned in this issue #111，I had the exact same situation.

For the sake of code robustness and reliability, I think this change is necessary.